### PR TITLE
Keyboard: changed "1" key to "F1"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ zig build --release=fast run-pengo
 
 ## Usage
 
-Press `1` to insert a coin, and `Enter` to start.
+Press `F1` to insert a coin, and `Enter` to start.
 
 In the game: `Arrow Keys` for direction and `Space` to push an ice block.
 

--- a/src/pengo.zig
+++ b/src/pengo.zig
@@ -54,8 +54,8 @@ fn keyToButton(key: Key) Pengo.Input {
         Key.up => .{ .p1_up = true },
         Key.down => .{ .p1_down = true },
         Key.space => .{ .p1_button = true },
-        '1' => .{ .p1_coin = true },
-        '2' => .{ .p2_coin = true },
+        Key.f1 => .{ .p1_coin = true },
+        Key.f2 => .{ .p2_coin = true },
         else => .{ .p1_start = true },
     };
 }


### PR DESCRIPTION
This fixes problems with layouts where "1" cannot be typed directly but only with a shift+other_key combination, like French layout.

Fixes #1 

Note that a proper fix would be to get the printed character instead of the codepoint that's being used, but I'm not sure if libvaxis can do that so for now let's use function keys would should work in every keyboard layout.